### PR TITLE
Fix unlisten_device_by_hash_element usage

### DIFF
--- a/main.c
+++ b/main.c
@@ -203,6 +203,8 @@ static void parse_events(void)
 #endif
 	while (1) {
 		fd_set activefds = evdevfds;
+		struct hash_element *elem, *tmp;
+
 #ifdef ENABLE_UDEV
 		if (is_udev) {
 			FD_SET(mon_fd, &activefds);
@@ -212,7 +214,7 @@ static void parse_events(void)
 			fprintf(stderr, "Error when polling events in select(): %s\n", strerror(errno));
 			terminate(3);
 		}
-		for (struct hash_element *elem = fdhash; elem != NULL; elem = elem->hh.next) {
+		HASH_ITER(hh, fdhash, elem, tmp) {
 			if (FD_ISSET(elem->fd, &activefds)) {
 				if (!handle_device_event(elem->fd)) {
 					unlisten_device_by_hash_element(elem);

--- a/watchdevs.c
+++ b/watchdevs.c
@@ -70,8 +70,6 @@ static void listen_device_if_not_present(const char *devnode)
 	FD_SET(elem->fd, &evdevfds);
 }
 
-#ifdef ENABLE_UDEV
-
 void unlisten_device_by_hash_element(struct hash_element *elem)
 {
 	close(elem->fd);
@@ -79,6 +77,8 @@ void unlisten_device_by_hash_element(struct hash_element *elem)
 	HASH_DEL(fdhash, elem);
 	hash_element_free(elem);
 }
+
+#ifdef ENABLE_UDEV
 
 static void unlisten_device_by_devnode(const char *devnode)
 {


### PR DESCRIPTION
Fix compilation without ENABLE_UDEV.

unlisten_device_by_hash_element calls hash_element_free, so use HASH_ITER for safe iteration.

Fixes: #9